### PR TITLE
Improve CSS readability with better typography and spacing

### DIFF
--- a/src/styles/Components/Footer.css
+++ b/src/styles/Components/Footer.css
@@ -159,7 +159,7 @@ footer::before {
 
 .footer-column p {
   margin-bottom: 20px;
-  line-height: 1.6;
+  line-height: 1.75;
   text-align: justify;
   hyphens: auto;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,13 @@
   --space-8: 3rem;     /* 48px */
   --space-10: 4rem;    /* 64px */
   --space-12: 5rem;    /* 80px */
+
+  /* Readability Variables */
+  --content-max-width: 70ch;       /* Optimal line length for reading */
+  --line-height-body: 1.75;        /* Improved line height for body text */
+  --line-height-relaxed: 1.9;      /* Extra relaxed for long-form content */
+  --letter-spacing-body: 0.01em;   /* Subtle letter spacing for readability */
+  --paragraph-spacing: 1.5em;      /* Space between paragraphs */
 }
 
 /* CSS Reset */
@@ -67,10 +74,11 @@ html {
 
 body {
   font-family: 'Montserrat', sans-serif;
-  line-height: 1.6;
+  line-height: var(--line-height-body);
   color: var(--text-dark);
   background-color: var(--light-gray);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-base);
+  letter-spacing: var(--letter-spacing-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
@@ -82,20 +90,22 @@ h1, h2, h3, h4, h5, h6 {
   font-family: 'Bebas Neue', sans-serif;
   font-weight: bold;
   color: var(--spartacus-burgundy);
-  line-height: 1.2;
-  margin-bottom: 0.5em;
+  line-height: 1.3;
+  margin-bottom: 0.75em;
+  letter-spacing: 0.02em;
 }
 
 h1 { font-size: var(--font-size-5xl); }
-h2 { font-size: var(--font-size-3xl); }
-h3 { font-size: var(--font-size-xl); }
-h4 { font-size: var(--font-size-lg); }
+h2 { font-size: var(--font-size-3xl); margin-top: 1.5em; }
+h3 { font-size: var(--font-size-xl); margin-top: 1.25em; }
+h4 { font-size: var(--font-size-lg); margin-top: 1em; }
 h5 { font-size: var(--font-size-base); }
 h6 { font-size: var(--font-size-sm); }
 
 p {
-  margin-bottom: 1em;
-  line-height: 1.8;
+  margin-bottom: var(--paragraph-spacing);
+  line-height: var(--line-height-relaxed);
+  max-width: var(--content-max-width);
 }
 
 a {
@@ -115,12 +125,14 @@ img {
 }
 
 ul, ol {
-  padding-left: 1.5rem;
-  margin-bottom: 1.5rem;
+  padding-left: 1.75rem;
+  margin-bottom: 1.75rem;
+  max-width: var(--content-max-width);
 }
 
 li {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.625rem;
+  line-height: var(--line-height-body);
 }
 
 /* Layout */
@@ -138,8 +150,18 @@ main {
 }
 
 .section {
-  margin-bottom: 80px;
+  margin-bottom: 100px;
   position: relative;
+}
+
+/* Text content container for optimal readability */
+.text-content {
+  max-width: var(--content-max-width);
+}
+
+.text-content p,
+.text-content li {
+  line-height: var(--line-height-relaxed);
 }
 
 .row {
@@ -202,10 +224,11 @@ main {
 }
 
 .hero p {
-  font-size: var(--font-size-base);
-  line-height: 1.8;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
   margin-bottom: var(--space-6);
-  max-width: 700px;
+  max-width: 650px;
+  letter-spacing: 0.015em;
 }
 
 /* Buttons */
@@ -254,11 +277,12 @@ main {
 /* Section Titles */
 .section-title {
   font-size: var(--font-size-3xl);
-  margin-bottom: var(--space-6);
+  margin-bottom: var(--space-8);
   color: var(--spartacus-burgundy);
   position: relative;
-  padding-bottom: 12px;
+  padding-bottom: 15px;
   text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 .section-title::after {
@@ -295,7 +319,7 @@ main {
   min-width: 250px;
   margin-bottom: 40px;
   background: white;
-  padding: 35px 30px;
+  padding: 40px 35px;
   border-radius: var(--border-radius-md);
   box-shadow: var(--box-shadow-sm);
   text-align: center;
@@ -303,6 +327,11 @@ main {
   overflow: hidden;
   z-index: 1;
   border-top: 4px solid var(--spartacus-red);
+}
+
+.feature p {
+  line-height: var(--line-height-relaxed);
+  max-width: none;
 }
 
 .feature-icon {

--- a/src/styles/pages/contact.css
+++ b/src/styles/pages/contact.css
@@ -82,9 +82,9 @@
 .contact-method p {
     display: flex;
     align-items: flex-start;
-    margin-bottom: 10px;
-    font-size: 15px;
-    line-height: 1.5;
+    margin-bottom: 12px;
+    font-size: 16px;
+    line-height: 1.7;
 }
 
 .contact-method i {
@@ -239,9 +239,10 @@
 }
 
 .confidential-contact-card p {
-    color: #666;
+    color: var(--dark-gray);
     margin-bottom: 15px;
-    font-size: 14px;
+    font-size: 15px;
+    line-height: 1.7;
 }
 
 .contact-email {
@@ -321,8 +322,8 @@
 }
 
 .faq-item p {
-    line-height: 1.7;
-    color: #555;
+    line-height: 1.8;
+    color: var(--dark-gray);
 }
 
 .faq-item a {

--- a/src/styles/pages/discounts.css
+++ b/src/styles/pages/discounts.css
@@ -187,9 +187,9 @@
 }
 
 .discount-description {
-    color: #555;
+    color: var(--dark-gray);
     margin-bottom: 20px;
-    line-height: 1.6;
+    line-height: 1.75;
 }
 
 .discount-subtitle {
@@ -271,9 +271,10 @@
 }
 
 .discount-placeholder-text {
-    color: #777;
+    color: var(--dark-gray);
     margin-bottom: 10px;
     max-width: 80%;
+    line-height: 1.7;
 }
 
 /* How To Section */
@@ -318,9 +319,9 @@
 }
 
 .how-to-text {
-    color: #555;
+    color: var(--dark-gray);
     margin-bottom: 25px;
-    line-height: 1.6;
+    line-height: 1.75;
 }
 
 .how-to-steps {
@@ -376,9 +377,9 @@
 }
 
 .discount-note-text p {
-    margin-bottom: 10px;
-    font-size: 14px;
-    line-height: 1.6;
+    margin-bottom: 12px;
+    font-size: 15px;
+    line-height: 1.75;
 }
 
 .discount-note-text p:last-child {

--- a/src/styles/pages/history.css
+++ b/src/styles/pages/history.css
@@ -65,7 +65,8 @@
 }
 
 .timeline-content p {
-  line-height: 1.8;
+  line-height: 1.85;
+  color: var(--dark-gray);
 }
 
 /* Founder Quote Section */

--- a/src/styles/pages/membership.css
+++ b/src/styles/pages/membership.css
@@ -90,9 +90,9 @@
 }
 
 .benefit-content p {
-    font-size: 14px;
-    line-height: 1.6;
-    color: #555;
+    font-size: 15px;
+    line-height: 1.75;
+    color: var(--dark-gray);
 }
 
 /* Membership Steps */
@@ -173,8 +173,8 @@
 
 .testimonial-content p {
     font-size: 18px;
-    line-height: 1.8;
-    color: #444;
+    line-height: 1.85;
+    color: var(--dark-gray);
     margin-bottom: 20px;
     font-style: italic;
 }

--- a/src/styles/pages/strengthsports.css
+++ b/src/styles/pages/strengthsports.css
@@ -164,8 +164,8 @@
 
 .competition-item p {
   margin-bottom: 15px;
-  line-height: 1.8;
-  color: #444;
+  line-height: 1.85;
+  color: var(--dark-gray);
 }
 
 /* Enhanced features section */

--- a/src/styles/registration-style.css
+++ b/src/styles/registration-style.css
@@ -39,10 +39,11 @@
 }
 
 .spartacus-form-header p {
-  margin-top: 10px;
-  font-size: 14px;
+  margin-top: 12px;
+  font-size: 15px;
   font-family: 'Montserrat', sans-serif;
-  opacity: 0.9;
+  opacity: 0.95;
+  line-height: 1.6;
 }
 
 .spartacus-logo-container {
@@ -130,12 +131,12 @@
 
 .spartacus-confirmation-screen p {
   font-size: 16px;
-  line-height: 1.8;
-  margin-bottom: 20px;
+  line-height: 1.85;
+  margin-bottom: 24px;
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
-  color: #444;
+  color: var(--dark-gray);
 }
 
 .spartacus-confirmation-buttons {


### PR DESCRIPTION
- Increase base font size from 14px to 16px for better legibility
- Add new readability CSS variables for consistent line-height and letter-spacing
- Set max-width on paragraphs (70ch) for optimal line length
- Improve line-height across body text (1.75) and paragraphs (1.9)
- Add subtle letter-spacing (0.01em) for improved character separation
- Increase spacing between headings and sections
- Improve text contrast by using --dark-gray instead of lighter grays (#444, #555, #666, #777)
- Update page-specific CSS files for consistency with global improvements