### PR TITLE
Fix API routes returning 404 by disabling prerendering

### DIFF
--- a/src/pages/api/contact.js
+++ b/src/pages/api/contact.js
@@ -1,5 +1,7 @@
 // src/pages/api/contact.js
 
+export const prerender = false;
+
 export async function POST({ request }) {
   const formData = await request.json();
   

--- a/src/pages/api/create-invoice.js
+++ b/src/pages/api/create-invoice.js
@@ -1,3 +1,5 @@
+export const prerender = false;
+
 const INVOICE_WORKER_URL = "https://nameless-hall-db47.herman-skledar.workers.dev";
 
 export async function POST({ request }) {


### PR DESCRIPTION
Astro's default static output mode prerenders all routes at build time, which means POST endpoints don't exist at runtime. Added `export const prerender = false` to both API routes so they are server-rendered by the Cloudflare adapter.

https://claude.ai/code/session_014JEAQSxCTXCHKJBk2uX1dm