### PR TITLE
Improve Conscribo invoice error handling

### DIFF
--- a/workers/invoice-handler/src/index.js
+++ b/workers/invoice-handler/src/index.js
@@ -38,7 +38,19 @@ async function conscriboRequest(payload, sessionId = null) {
     body: JSON.stringify(payload),
   });
 
-  const data = await response.json();
+  const responseText = await response.text();
+  if (!responseText) {
+    throw new Error(`Conscribo returned an empty response (status ${response.status}).`);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(responseText);
+  } catch (error) {
+    throw new Error(
+      `Conscribo returned non-JSON response (status ${response.status}): ${responseText.slice(0, 200)}`
+    );
+  }
   const rootKey = Object.keys(data).find(
     (k) => k.toLowerCase() === "result" || k.toLowerCase() === "results"
   );
@@ -117,6 +129,34 @@ async function lookupMember(sessionId, identifier) {
   };
 }
 
+function extractConscriboErrorMessage(result) {
+  if (!result || typeof result !== "object") return null;
+
+  const candidates = [
+    "errorMessage",
+    "errormessage",
+    "message",
+    "error",
+    "errors",
+    "errorMessages",
+  ];
+
+  for (const key of candidates) {
+    if (result[key]) {
+      const value = result[key];
+      if (typeof value === "string") return value;
+      if (Array.isArray(value)) return value.filter(Boolean).join(", ");
+      if (typeof value === "object") {
+        if (value.message) return value.message;
+        if (value.error) return value.error;
+        if (value.detail) return value.detail;
+      }
+    }
+  }
+
+  return null;
+}
+
 export default {
   async fetch(request) {
     const origin = request.headers.get("Origin");
@@ -161,7 +201,7 @@ export default {
       }
 
       const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
-      const totalFormatted = total.toFixed(2).replace(".", ",");
+      const totalFormatted = total.toFixed(2);
 
       const lineDescriptions = items
         .map((item) => `${item.quantity}x ${item.name} @ €${item.price.toFixed(2)}`)
@@ -218,7 +258,9 @@ export default {
       return new Response(
         JSON.stringify({
           success: false,
-          message: "Failed to create invoice in Conscribo. Please try again or contact the board.",
+          message:
+            extractConscriboErrorMessage(result) ||
+            "Failed to create invoice in Conscribo. Please try again or contact the board.",
           debug: result,
         }),
         { status: 500, headers: corsHeaders(origin) }


### PR DESCRIPTION
### Motivation
- The Conscribo integration sometimes returns empty or non-JSON responses which produced vague server errors and made diagnosing invoice failures difficult.
- It should surface any Conscribo-provided error messages to the frontend so users and maintainers get clearer feedback when invoice creation fails.
- Amount formatting for the Conscribo API payload should use dot-decimal notation to avoid mismatched numeric formats.

### Description
- Replace `response.json()` with reading `response.text()` and explicit JSON parsing to throw clearer errors for empty or non-JSON replies. 
- Add `extractConscriboErrorMessage(result)` to extract human-friendly messages from common Conscribo error fields and return them to the client when available. 
- Stop converting `total` to comma-decimal for the API payload and keep `totalFormatted` in dot-decimal via `total.toFixed(2)`. 
- Return the extracted Conscribo message (if found) in the `message` field of the failure response and include the raw `debug` payload.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860ab666348327812c541ffcadb562)