### PR TITLE
Enlarge and simplify member portal layout

### DIFF
--- a/src/pages/member-portal.astro
+++ b/src/pages/member-portal.astro
@@ -15,43 +15,45 @@ import Footer from '../components/Footer.astro';
             background: linear-gradient(rgba(55, 0, 27, 0.85), rgba(186, 19, 26, 0.75)), url('/images/hero-membership.jpg');
             background-size: cover;
             background-position: center;
-            padding: 120px 0 60px;
+            padding: 150px 0 90px;
             text-align: center;
-            margin-bottom: 60px;
+            margin-bottom: 70px;
         }
 
         .portal-hero h1 {
             color: white;
-            margin-bottom: 15px;
-            font-size: 48px;
+            margin-bottom: 18px;
+            font-size: 56px;
+            letter-spacing: 2px;
         }
 
         .portal-hero h2 {
             color: var(--spartacus-yellow);
-            margin-bottom: 25px;
-            font-size: 28px;
+            margin-bottom: 10px;
+            font-size: 32px;
+            font-weight: 600;
         }
 
         .portal-container {
-            max-width: 1100px;
-            margin: 0 auto 80px;
-            padding: 0 20px;
+            max-width: 1300px;
+            margin: 0 auto 90px;
+            padding: 0 24px;
         }
 
         .portal-intro {
             background: white;
-            border-radius: 8px;
-            padding: 30px;
+            border-radius: 12px;
+            padding: 40px 50px;
             margin-bottom: 40px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
             text-align: center;
-            border-top: 5px solid var(--spartacus-red);
+            border-top: 6px solid var(--spartacus-red);
         }
 
         .portal-intro h2 {
             color: var(--spartacus-burgundy);
-            margin-bottom: 20px;
-            font-size: 28px;
+            margin-bottom: 16px;
+            font-size: 32px;
             position: relative;
             padding-bottom: 10px;
             display: inline-block;
@@ -68,37 +70,10 @@ import Footer from '../components/Footer.astro';
         }
 
         .portal-intro p {
-            max-width: 800px;
-            margin: 0 auto 20px;
-            line-height: 1.7;
-            font-size: 16px;
-        }
-
-        .portal-features {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-            gap: 20px;
-            margin: 30px 0;
-        }
-
-        .portal-feature {
-            display: flex;
-            align-items: center;
-            background: #f8f8f8;
-            padding: 15px 20px;
-            border-radius: 8px;
-            min-width: 220px;
-        }
-
-        .feature-icon {
-            color: var(--spartacus-red);
-            font-size: 24px;
-            margin-right: 15px;
-        }
-
-        .feature-text {
-            font-weight: 500;
+            max-width: 900px;
+            margin: 0 auto;
+            line-height: 1.8;
+            font-size: 18px;
         }
 
         /* Tab Navigation */
@@ -112,12 +87,12 @@ import Footer from '../components/Footer.astro';
         .portal-tab {
             flex: 1;
             min-width: 200px;
-            padding: 20px 30px;
+            padding: 24px 36px;
             background: #f5f5f5;
             border: none;
             border-radius: 8px 8px 0 0;
             cursor: pointer;
-            font-size: 16px;
+            font-size: 18px;
             font-weight: 600;
             color: #666;
             transition: all 0.3s ease;
@@ -139,33 +114,16 @@ import Footer from '../components/Footer.astro';
         }
 
         .portal-tab i {
-            font-size: 20px;
-        }
-
-        .portal-tab-label {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            text-align: left;
-        }
-
-        .portal-tab-title {
-            font-size: 16px;
-        }
-
-        .portal-tab-subtitle {
-            font-size: 12px;
-            font-weight: 400;
-            opacity: 0.8;
+            font-size: 22px;
         }
 
         /* Tab Content */
         .portal-tab-content {
             background: white;
-            border-radius: 0 0 8px 8px;
-            padding: 30px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-            min-height: 500px;
+            border-radius: 0 0 12px 12px;
+            padding: 40px;
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+            min-height: 560px;
         }
 
         .portal-tab-pane {
@@ -178,70 +136,43 @@ import Footer from '../components/Footer.astro';
 
         .tab-header {
             text-align: center;
-            margin-bottom: 30px;
-            padding-bottom: 20px;
+            margin-bottom: 35px;
+            padding-bottom: 22px;
             border-bottom: 1px solid #eee;
         }
 
         .tab-header h3 {
             color: var(--spartacus-burgundy);
-            font-size: 24px;
-            margin-bottom: 10px;
+            font-size: 26px;
+            margin-bottom: 12px;
         }
 
         .tab-header p {
             color: #666;
-            font-size: 15px;
-            max-width: 600px;
+            font-size: 16px;
+            max-width: 700px;
             margin: 0 auto;
         }
 
         .conscribo-app-container {
             width: 100%;
-            min-height: 450px;
-        }
-
-        /* Document categories info */
-        .document-categories {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 15px;
-            margin-bottom: 30px;
-        }
-
-        .doc-category {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 15px;
-            background: #f8f8f8;
-            border-radius: 8px;
-            border-left: 3px solid var(--spartacus-red);
-        }
-
-        .doc-category i {
-            font-size: 20px;
-            color: var(--spartacus-red);
-        }
-
-        .doc-category span {
-            font-weight: 500;
-            font-size: 14px;
+            min-height: 520px;
         }
 
         .help-section {
-            margin-top: 60px;
+            margin-top: 70px;
             text-align: center;
         }
 
         .help-section h3 {
             color: var(--spartacus-burgundy);
             margin-bottom: 20px;
-            font-size: 22px;
+            font-size: 24px;
         }
 
         .help-section p {
             margin-bottom: 20px;
+            font-size: 17px;
         }
 
         .help-email {
@@ -263,25 +194,19 @@ import Footer from '../components/Footer.astro';
 
         @media (max-width: 768px) {
             .portal-hero {
-                padding: 100px 0 50px;
+                padding: 110px 0 60px;
             }
 
             .portal-hero h1 {
-                font-size: 36px;
+                font-size: 40px;
             }
 
             .portal-hero h2 {
-                font-size: 22px;
+                font-size: 24px;
             }
 
-            .portal-features {
-                flex-direction: column;
-                align-items: center;
-            }
-
-            .portal-feature {
-                width: 100%;
-                max-width: 350px;
+            .portal-intro {
+                padding: 32px 28px;
             }
 
             .portal-tabs {
@@ -300,16 +225,7 @@ import Footer from '../components/Footer.astro';
 
             .portal-tab-content {
                 border-radius: 8px;
-            }
-
-            .document-categories {
-                grid-template-columns: 1fr 1fr;
-            }
-        }
-
-        @media (max-width: 480px) {
-            .document-categories {
-                grid-template-columns: 1fr;
+                padding: 30px;
             }
         }
     </style>
@@ -332,29 +248,7 @@ import Footer from '../components/Footer.astro';
             <!-- Introduction -->
             <div class="portal-intro">
                 <h2>WELCOME TO YOUR MEMBERSHIP PORTAL</h2>
-                <p>This secure portal allows you to manage your T.S.K.V. Spartacus membership details and access important association documents. Update your personal information, view meeting minutes, financial reports, and photo albums.</p>
-
-                <div class="portal-features">
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-user-edit"></i></span>
-                        <span class="feature-text">Update Personal Info</span>
-                    </div>
-
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-university"></i></span>
-                        <span class="feature-text">Manage Payment Details</span>
-                    </div>
-
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-folder-open"></i></span>
-                        <span class="feature-text">View Documents</span>
-                    </div>
-
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-images"></i></span>
-                        <span class="feature-text">Browse Photos</span>
-                    </div>
-                </div>
+                <p>Access your membership details and association documents in one place. Use the tabs below to update your information or review official files.</p>
             </div>
 
             <!-- Conscribo Portal Loader -->
@@ -364,17 +258,11 @@ import Footer from '../components/Footer.astro';
             <div class="portal-tabs">
                 <button class="portal-tab active" data-tab="membership">
                     <i class="fas fa-id-card"></i>
-                    <span class="portal-tab-label">
-                        <span class="portal-tab-title">Membership Details</span>
-                        <span class="portal-tab-subtitle">Update your information</span>
-                    </span>
+                    Membership Details
                 </button>
                 <button class="portal-tab" data-tab="documents">
                     <i class="fas fa-archive"></i>
-                    <span class="portal-tab-label">
-                        <span class="portal-tab-title">Association Documents</span>
-                        <span class="portal-tab-subtitle">Minutes, finances & photos</span>
-                    </span>
+                    Association Documents
                 </button>
             </div>
 
@@ -394,24 +282,6 @@ import Footer from '../components/Footer.astro';
                     <div class="tab-header">
                         <h3>ASSOCIATION DOCUMENTS</h3>
                         <p>Access meeting minutes, financial reports, photos, and other important association files.</p>
-                    </div>
-                    <div class="document-categories">
-                        <div class="doc-category">
-                            <i class="fas fa-file-alt"></i>
-                            <span>Meeting Minutes</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-chart-pie"></i>
-                            <span>Financial Reports</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-camera"></i>
-                            <span>Photo Albums</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-file-contract"></i>
-                            <span>Policies</span>
-                        </div>
                     </div>
                     <div class="conscribo-app-container" data-id="a071d903b8"></div>
                 </div>


### PR DESCRIPTION
### Motivation

- Make the member portal visually larger and more spacious for better readability and prominence.  
- Remove unnecessary UI elements to simplify the interface and focus on the two main portal sections.  
- Ensure the layout stays usable on smaller screens with adjusted responsive rules.

### Description

- Increased hero, typography, spacing and container sizing by updating CSS (hero padding, `h1`/`h2` sizes, `max-width`, paddings, and letter-spacing) to create a larger feel.  
- Simplified the introduction by trimming the copy and removing the feature tiles block and document category tiles to reduce clutter.  
- Simplified tab labels to plain text and adjusted tab/pane styling (padding, font-size, icon size, border-radius, content padding and `min-height`) for a cleaner tab UI.  
- Updated responsive breakpoints and mobile padding to preserve readability on small screens and increased the `conscribo-app-container` minimum height for the embedded portal.

### Testing

- Started the dev server using `npm run dev`, and the `/member-portal` page returned `200` successfully.  
- Captured a full-page screenshot with a Playwright script which completed and produced `artifacts/member-portal.png`.  
- Dev server logs showed a `404` for `/images/hero-membership.jpg`, indicating a missing hero asset but the layout changes rendered successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986117c78b88327b493c36f3d0d5e73)