### PR TITLE
Add events subscription page with Conscribo embeds

### DIFF
--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -1,0 +1,76 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <BaseHead title="Events | T.S.K.V. Spartacus" description="View Spartacus activities and subscribe to events through our event portal." />
+    <style>
+        .events-page {
+            max-width: 1100px;
+            margin: 120px auto 80px;
+            padding: 0 20px;
+        }
+
+        .events-header {
+            margin-bottom: 30px;
+            text-align: center;
+        }
+
+        .events-header h1 {
+            color: var(--spartacus-burgundy);
+            margin-bottom: 10px;
+        }
+
+        .events-grid {
+            display: grid;
+            gap: 24px;
+        }
+
+        .events-card {
+            background: #fff;
+            border-radius: 10px;
+            padding: 24px;
+            box-shadow: 0 4px 18px rgba(0, 0, 0, 0.08);
+            border-top: 4px solid var(--spartacus-red);
+        }
+
+        .events-card h2 {
+            margin-bottom: 12px;
+            color: var(--spartacus-burgundy);
+        }
+
+        .conscribo-app-container {
+            min-height: 480px;
+        }
+    </style>
+</head>
+<body>
+    <Header />
+
+    <main class="events-page">
+        <div class="events-header">
+            <h1>Subscribe to Spartacus Events</h1>
+            <p>Browse all activities below and reserve your spot for a specific event.</p>
+        </div>
+
+        <div class="events-grid">
+            <section class="events-card">
+                <h2>Event Overview</h2>
+                <script async src="https://leden.conscribo.nl/TSKVSpartacus/portal/loader" type="module"></script>
+                <div class="conscribo-app-container" data-page="activity_overview"></div>
+            </section>
+
+            <section class="events-card">
+                <h2>Reserve for an Event</h2>
+                <div class="conscribo-app-container" data-page="activity_reservation" data-options="b58ee071eb"></div>
+            </section>
+        </div>
+    </main>
+
+    <Footer />
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated page where members can browse activities and subscribe to events through the Conscribo portal. 
- Reuse existing site layout components and styles to keep the new page consistent with the rest of the site.

### Description
- Added a new page at `src/pages/events.astro` that uses the shared `BaseHead`, `Header`, and `Footer` components and sets page metadata for events. 
- Embedded the Conscribo activity overview widget with a loader script and a container using `data-page="activity_overview"`. 
- Embedded the Conscribo reservation widget using a container with `data-page="activity_reservation"` and `data-options="b58ee071eb"`, relying on the same loader. 
- Included lightweight page-specific styling for layout, card appearance, and `conscribo-app-container` sizing.

### Testing
- Ran `npm run build` successfully and the build completed without errors. 
- The route `/events/index.html` was prerendered during the build process and produced as part of the static output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89ff914f08327b2031a70459ad44a)