### PR TITLE
Add interactive Member Portal with login/session and Conscribo widgets; minor Header cleanup

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -20,9 +20,7 @@ import '../styles/Components/header.css';
                 <li><a href="/strengthsports" class="nav-link">Strength Sports</a></li>
                 <li><a href="/committee" class="nav-link">Committees</a></li>
                 <li><a href="/contact" class="nav-link">Contact</a></li>
-                <li>
-                    <a href="/shop" class="nav-link">Shop</a>
-                </li>
+                <li><a href="/shop" class="nav-link">Shop</a></li>
                 <!-- New Member Portal Link -->
                 <li>
                     <a href="/member-portal" class="nav-link portal-link">

--- a/src/pages/member-portal.astro
+++ b/src/pages/member-portal.astro
@@ -2,455 +2,188 @@
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+
+const proxyUrl = 'https://tskv-conscribo-proxy.herman-skledar.workers.dev/';
+const widgets = {
+  details: 'af04808317',
+  events: '',
+  files: 'a071d903b8',
+};
 ---
 
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <BaseHead title="Member Portal | T.S.K.V. Spartacus" description="Access your T.S.K.V. Spartacus membership details, update your information, view association documents, and manage your account." />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
-    <style>
-        /* Portal page specific styles */
-        .portal-hero {
-            background: linear-gradient(rgba(55, 0, 27, 0.85), rgba(186, 19, 26, 0.75)), url('/images/hero-membership.jpg');
-            background-size: cover;
-            background-position: center;
-            padding: 120px 0 60px;
-            text-align: center;
-            margin-bottom: 60px;
-        }
-
-        .portal-hero h1 {
-            color: white;
-            margin-bottom: 15px;
-            font-size: 48px;
-        }
-
-        .portal-hero h2 {
-            color: var(--spartacus-yellow);
-            margin-bottom: 25px;
-            font-size: 28px;
-        }
-
-        .portal-container {
-            max-width: 1100px;
-            margin: 0 auto 80px;
-            padding: 0 20px;
-        }
-
-        .portal-intro {
-            background: white;
-            border-radius: 8px;
-            padding: 30px;
-            margin-bottom: 40px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-            text-align: center;
-            border-top: 5px solid var(--spartacus-red);
-        }
-
-        .portal-intro h2 {
-            color: var(--spartacus-burgundy);
-            margin-bottom: 20px;
-            font-size: 28px;
-            position: relative;
-            padding-bottom: 10px;
-            display: inline-block;
-        }
-
-        .portal-intro h2::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            height: 3px;
-            background: var(--spartacus-red);
-        }
-
-        .portal-intro p {
-            max-width: 800px;
-            margin: 0 auto 20px;
-            line-height: 1.7;
-            font-size: 16px;
-        }
-
-        .portal-features {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-            gap: 20px;
-            margin: 30px 0;
-        }
-
-        .portal-feature {
-            display: flex;
-            align-items: center;
-            background: #f8f8f8;
-            padding: 15px 20px;
-            border-radius: 8px;
-            min-width: 220px;
-        }
-
-        .feature-icon {
-            color: var(--spartacus-red);
-            font-size: 24px;
-            margin-right: 15px;
-        }
-
-        .feature-text {
-            font-weight: 500;
-        }
-
-        /* Tab Navigation */
-        .portal-tabs {
-            display: flex;
-            gap: 10px;
-            margin-bottom: 0;
-            flex-wrap: wrap;
-        }
-
-        .portal-tab {
-            flex: 1;
-            min-width: 200px;
-            padding: 20px 30px;
-            background: #f5f5f5;
-            border: none;
-            border-radius: 8px 8px 0 0;
-            cursor: pointer;
-            font-size: 16px;
-            font-weight: 600;
-            color: #666;
-            transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 12px;
-        }
-
-        .portal-tab:hover {
-            background: #e8e8e8;
-            color: var(--spartacus-burgundy);
-        }
-
-        .portal-tab.active {
-            background: white;
-            color: var(--spartacus-burgundy);
-            box-shadow: 0 -3px 0 var(--spartacus-red) inset;
-        }
-
-        .portal-tab i {
-            font-size: 20px;
-        }
-
-        .portal-tab-label {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            text-align: left;
-        }
-
-        .portal-tab-title {
-            font-size: 16px;
-        }
-
-        .portal-tab-subtitle {
-            font-size: 12px;
-            font-weight: 400;
-            opacity: 0.8;
-        }
-
-        /* Tab Content */
-        .portal-tab-content {
-            background: white;
-            border-radius: 0 0 8px 8px;
-            padding: 30px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-            min-height: 500px;
-        }
-
-        .portal-tab-pane {
-            display: none;
-        }
-
-        .portal-tab-pane.active {
-            display: block;
-        }
-
-        .tab-header {
-            text-align: center;
-            margin-bottom: 30px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid #eee;
-        }
-
-        .tab-header h3 {
-            color: var(--spartacus-burgundy);
-            font-size: 24px;
-            margin-bottom: 10px;
-        }
-
-        .tab-header p {
-            color: #666;
-            font-size: 15px;
-            max-width: 600px;
-            margin: 0 auto;
-        }
-
-        .conscribo-app-container {
-            width: 100%;
-            min-height: 450px;
-        }
-
-        /* Document categories info */
-        .document-categories {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 15px;
-            margin-bottom: 30px;
-        }
-
-        .doc-category {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 15px;
-            background: #f8f8f8;
-            border-radius: 8px;
-            border-left: 3px solid var(--spartacus-red);
-        }
-
-        .doc-category i {
-            font-size: 20px;
-            color: var(--spartacus-red);
-        }
-
-        .doc-category span {
-            font-weight: 500;
-            font-size: 14px;
-        }
-
-        .help-section {
-            margin-top: 60px;
-            text-align: center;
-        }
-
-        .help-section h3 {
-            color: var(--spartacus-burgundy);
-            margin-bottom: 20px;
-            font-size: 22px;
-        }
-
-        .help-section p {
-            margin-bottom: 20px;
-        }
-
-        .help-email {
-            display: inline-flex;
-            align-items: center;
-            color: var(--spartacus-red);
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s ease;
-        }
-
-        .help-email i {
-            margin-right: 8px;
-        }
-
-        .help-email:hover {
-            color: var(--spartacus-burgundy);
-        }
-
-        @media (max-width: 768px) {
-            .portal-hero {
-                padding: 100px 0 50px;
-            }
-
-            .portal-hero h1 {
-                font-size: 36px;
-            }
-
-            .portal-hero h2 {
-                font-size: 22px;
-            }
-
-            .portal-features {
-                flex-direction: column;
-                align-items: center;
-            }
-
-            .portal-feature {
-                width: 100%;
-                max-width: 350px;
-            }
-
-            .portal-tabs {
-                flex-direction: column;
-            }
-
-            .portal-tab {
-                border-radius: 8px;
-                margin-bottom: 5px;
-            }
-
-            .portal-tab.active {
-                border-radius: 8px;
-                box-shadow: 0 0 0 2px var(--spartacus-red);
-            }
-
-            .portal-tab-content {
-                border-radius: 8px;
-            }
-
-            .document-categories {
-                grid-template-columns: 1fr 1fr;
-            }
-        }
-
-        @media (max-width: 480px) {
-            .document-categories {
-                grid-template-columns: 1fr;
-            }
-        }
-    </style>
+  <BaseHead title="Member Portal | T.S.K.V. Spartacus" description="Secure Spartacus member portal for profile edits, events, and shared files." />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+  <style>
+    .portal-shell{max-width:1150px;margin:120px auto 80px;padding:0 20px}
+    .portal-card{background:#fff;border-radius:12px;box-shadow:0 6px 20px rgba(0,0,0,.08);padding:28px}
+    .portal-hero{margin-bottom:24px;border-left:5px solid var(--spartacus-red)}
+    .portal-hero h1{margin:0 0 8px;color:var(--spartacus-burgundy)}
+    .portal-hero p{margin:0;color:#555;line-height:1.6}
+    .auth-grid{display:grid;grid-template-columns:1fr auto;gap:12px;margin-top:18px}
+    .auth-input{padding:12px 14px;border:1px solid #ddd;border-radius:8px;font-size:15px}
+    .auth-btn{padding:12px 20px;border:none;border-radius:8px;background:var(--spartacus-red);color:#fff;font-weight:700;cursor:pointer}
+    .auth-btn:disabled{opacity:.5;cursor:not-allowed}
+    .auth-status{margin-top:12px;font-size:14px}
+    .auth-status.error{color:#b91c1c}
+    .auth-status.success{color:#0f766e}
+    .portal-tabs{display:flex;gap:8px;flex-wrap:wrap;margin:28px 0 0}
+    .portal-tab{border:none;border-radius:10px 10px 0 0;padding:14px 20px;background:#f3f4f6;color:#666;font-weight:700;cursor:pointer}
+    .portal-tab.active{background:#fff;color:var(--spartacus-burgundy);box-shadow:inset 0 -3px 0 var(--spartacus-red)}
+    .portal-pane-wrap{background:#fff;border-radius:0 12px 12px 12px;box-shadow:0 6px 20px rgba(0,0,0,.08);padding:24px;min-height:420px}
+    .portal-pane{display:none}
+    .portal-pane.active{display:block}
+    .pane-head h2{margin:0;color:var(--spartacus-burgundy)}
+    .pane-head p{margin:8px 0 20px;color:#666}
+    .widget{min-height:260px;border:1px dashed #ddd;border-radius:10px;padding:12px;background:#fafafa}
+    .hint{margin-top:14px;padding:12px;border-radius:8px;background:#fff8e1;font-size:14px}
+    .hidden-until-login{opacity:.45;pointer-events:none;transition:.2s}
+    .hidden-until-login.unlocked{opacity:1;pointer-events:auto}
+    @media (max-width:768px){.portal-shell{margin-top:100px}.auth-grid{grid-template-columns:1fr}}
+  </style>
 </head>
 <body>
-    <!-- Header -->
-    <Header />
-
-    <!-- Hero Section -->
-    <section class="portal-hero">
-        <div class="container">
-            <h1>MEMBER PORTAL</h1>
-            <h2>MANAGE YOUR SPARTACUS MEMBERSHIP</h2>
-        </div>
+  <Header />
+  <main class="portal-shell">
+    <section class="portal-card portal-hero">
+      <h1>Spartacus Members Portal</h1>
+      <p>Edit your member details, register for events, and download files like minutes and photos. Use your member code or email to unlock the portal.</p>
+      <div class="auth-grid">
+        <input id="memberIdentifier" class="auth-input" type="text" placeholder="Member code or email" autocomplete="username" />
+        <button id="memberLoginButton" class="auth-btn">Log in</button>
+      </div>
+      <div id="authStatus" class="auth-status" aria-live="polite"></div>
+      <button id="memberLogoutButton" class="auth-btn" style="display:none;margin-top:12px;background:#374151">Log out</button>
     </section>
 
-    <!-- Main Content -->
-    <main>
-        <div class="portal-container">
-            <!-- Introduction -->
-            <div class="portal-intro">
-                <h2>WELCOME TO YOUR MEMBERSHIP PORTAL</h2>
-                <p>This secure portal allows you to manage your T.S.K.V. Spartacus membership details and access important association documents. Update your personal information, view meeting minutes, financial reports, and photo albums.</p>
+    <section class="hidden-until-login" id="portalContent">
+      <div class="portal-tabs">
+        <button class="portal-tab active" data-tab="details"><i class="fas fa-user-edit"></i> My Details</button>
+        <button class="portal-tab" data-tab="events"><i class="fas fa-calendar-check"></i> Events</button>
+        <button class="portal-tab" data-tab="files"><i class="fas fa-folder-open"></i> Files</button>
+      </div>
+      <div class="portal-pane-wrap">
+        <article class="portal-pane active" id="details-tab">
+          <div class="pane-head">
+            <h2>Edit profile details</h2>
+            <p>Update address, phone, IBAN/payment, and emergency/contact details in your official member record.</p>
+          </div>
+          <div class="widget" data-id={widgets.details}></div>
+        </article>
 
-                <div class="portal-features">
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-user-edit"></i></span>
-                        <span class="feature-text">Update Personal Info</span>
-                    </div>
+        <article class="portal-pane" id="events-tab">
+          <div class="pane-head">
+            <h2>View & subscribe to events</h2>
+            <p>See upcoming activities, open event pages, and register directly from your account.</p>
+          </div>
+          {widgets.events ? (
+            <div class="widget" data-id={widgets.events}></div>
+          ) : (
+            <div class="hint">Events widget is not configured yet. Add your Conscribo events block ID in <code>widgets.events</code> at the top of this file.</div>
+          )}
+        </article>
 
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-university"></i></span>
-                        <span class="feature-text">Manage Payment Details</span>
-                    </div>
+        <article class="portal-pane" id="files-tab">
+          <div class="pane-head">
+            <h2>Download minutes, reports & photos</h2>
+            <p>Browse shared folders, committee minutes, and media archives uploaded in Conscribo.</p>
+          </div>
+          <div class="widget" data-id={widgets.files}></div>
+        </article>
+      </div>
+    </section>
+  </main>
+  <Footer />
 
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-folder-open"></i></span>
-                        <span class="feature-text">View Documents</span>
-                    </div>
+  <script async src="https://leden.conscribo.nl/TSKVSpartacus/portal/loader" type="module"></script>
+  <script define:vars={{ proxyUrl }}>
+    const portalContent = document.getElementById('portalContent');
+    const authStatus = document.getElementById('authStatus');
+    const loginButton = document.getElementById('memberLoginButton');
+    const logoutButton = document.getElementById('memberLogoutButton');
+    const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+    const memberIdentifier = document.getElementById('memberIdentifier');
 
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-images"></i></span>
-                        <span class="feature-text">Browse Photos</span>
-                    </div>
-                </div>
-            </div>
+    async function loginMember() {
+      const identifier = memberIdentifier.value.trim();
+      if (!identifier) {
+        authStatus.textContent = 'Please enter your member code or email.';
+        authStatus.className = 'auth-status error';
+        return;
+      }
+      loginButton.disabled = true;
+      authStatus.textContent = 'Checking membership…';
+      authStatus.className = 'auth-status';
 
-            <!-- Conscribo Portal Loader -->
-            <script async src="https://leden.conscribo.nl/TSKVSpartacus/portal/loader" type="module"></script>
-
-            <!-- Tab Navigation -->
-            <div class="portal-tabs">
-                <button class="portal-tab active" data-tab="membership">
-                    <i class="fas fa-id-card"></i>
-                    <span class="portal-tab-label">
-                        <span class="portal-tab-title">Membership Details</span>
-                        <span class="portal-tab-subtitle">Update your information</span>
-                    </span>
-                </button>
-                <button class="portal-tab" data-tab="documents">
-                    <i class="fas fa-archive"></i>
-                    <span class="portal-tab-label">
-                        <span class="portal-tab-title">Association Documents</span>
-                        <span class="portal-tab-subtitle">Minutes, finances & photos</span>
-                    </span>
-                </button>
-            </div>
-
-            <!-- Tab Content -->
-            <div class="portal-tab-content">
-                <!-- Membership Details Tab -->
-                <div class="portal-tab-pane active" id="membership-tab">
-                    <div class="tab-header">
-                        <h3>YOUR MEMBERSHIP INFORMATION</h3>
-                        <p>View and update your personal details, contact information, and payment preferences.</p>
-                    </div>
-                    <div class="conscribo-app-container" data-id="af04808317"></div>
-                </div>
-
-                <!-- Documents Tab -->
-                <div class="portal-tab-pane" id="documents-tab">
-                    <div class="tab-header">
-                        <h3>ASSOCIATION DOCUMENTS</h3>
-                        <p>Access meeting minutes, financial reports, photos, and other important association files.</p>
-                    </div>
-                    <div class="document-categories">
-                        <div class="doc-category">
-                            <i class="fas fa-file-alt"></i>
-                            <span>Meeting Minutes</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-chart-pie"></i>
-                            <span>Financial Reports</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-camera"></i>
-                            <span>Photo Albums</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-file-contract"></i>
-                            <span>Policies</span>
-                        </div>
-                    </div>
-                    <div class="conscribo-app-container" data-id="a071d903b8"></div>
-                </div>
-            </div>
-
-            <!-- Help Section -->
-            <div class="help-section">
-                <h3>NEED ASSISTANCE?</h3>
-                <p>If you encounter any issues or have questions about your membership, please contact our secretary:</p>
-                <a href="mailto:secretary@tskvspartacus.nl" class="help-email">
-                    <i class="fas fa-envelope"></i> secretary@tskvspartacus.nl
-                </a>
-            </div>
-        </div>
-    </main>
-
-    <!-- Footer -->
-    <Footer />
-
-    <script>
-        // Tab switching functionality
-        document.addEventListener('DOMContentLoaded', function() {
-            const tabs = document.querySelectorAll('.portal-tab');
-            const panes = document.querySelectorAll('.portal-tab-pane');
-
-            tabs.forEach(tab => {
-                tab.addEventListener('click', function() {
-                    const targetTab = this.dataset.tab;
-
-                    // Remove active class from all tabs and panes
-                    tabs.forEach(t => t.classList.remove('active'));
-                    panes.forEach(p => p.classList.remove('active'));
-
-                    // Add active class to clicked tab and corresponding pane
-                    this.classList.add('active');
-                    document.getElementById(targetTab + '-tab').classList.add('active');
-                });
-            });
+      try {
+        const response = await fetch(proxyUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'login', identifier })
         });
-    </script>
+        const payload = await response.json();
+
+        if (!response.ok || !payload.success) {
+          throw new Error(payload?.error?.message || 'Login failed');
+        }
+
+        localStorage.setItem('spartacus_member_session', JSON.stringify({
+          member: payload.member,
+          issuedAt: Date.now(),
+        }));
+        authStatus.textContent = `Welcome ${payload.member.fullName || payload.member.code}. Portal unlocked.`;
+        authStatus.className = 'auth-status success';
+        portalContent.classList.add('unlocked');
+        logoutButton.style.display = 'inline-block';
+      } catch (error) {
+        authStatus.textContent = error.message;
+        authStatus.className = 'auth-status error';
+      } finally {
+        loginButton.disabled = false;
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const tabs = document.querySelectorAll('.portal-tab');
+      const panes = document.querySelectorAll('.portal-pane');
+
+      tabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+          tabs.forEach((t) => t.classList.remove('active'));
+          panes.forEach((p) => p.classList.remove('active'));
+          tab.classList.add('active');
+          document.getElementById(`${tab.dataset.tab}-tab`).classList.add('active');
+        });
+      });
+
+      const existingMember = localStorage.getItem('spartacus_member_session');
+      if (existingMember) {
+        const parsed = JSON.parse(existingMember);
+        if (parsed.issuedAt && Date.now() - parsed.issuedAt < SESSION_TTL_MS) {
+          const member = parsed.member || {};
+          authStatus.textContent = `Welcome back ${member.fullName || member.code}. Portal unlocked.`;
+          authStatus.className = 'auth-status success';
+          portalContent.classList.add('unlocked');
+          logoutButton.style.display = 'inline-block';
+        } else {
+          localStorage.removeItem('spartacus_member_session');
+        }
+      }
+
+      loginButton.addEventListener('click', loginMember);
+      logoutButton.addEventListener('click', () => {
+        localStorage.removeItem('spartacus_member_session');
+        portalContent.classList.remove('unlocked');
+        authStatus.textContent = 'You are logged out.';
+        authStatus.className = 'auth-status';
+        logoutButton.style.display = 'none';
+      });
+      memberIdentifier.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') loginMember();
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a secure, user-facing Member Portal that unlocks Conscribo widgets after member authentication.
- Replace the old static portal layout with a compact, responsive UI and simplified styles to improve usability on mobile and desktop.
- Use a proxy endpoint to validate member identifiers centrally and avoid exposing service internals in the client.

### Description
- Minor tidy in `Header.astro` collapsing the `Shop` list item into a single-line element.
- Replace the previous `src/pages/member-portal.astro` with a redesigned portal that defines `proxyUrl` and a `widgets` map and inlines a compact CSS theme for the portal.
- Add an authentication UI (member code/email input, `Log in`/`Log out` buttons), client-side login flow that `POST`s to `proxyUrl`, and session persistence in `localStorage` with a `SESSION_TTL_MS` of 12 hours.
- Implement tabbed panes (`details`, `events`, `files`) with widget containers populated via `data-id`, conditional rendering for an unconfigured events widget, inclusion of the Conscribo loader script, and JS handlers for tab switching, login/logout, and Enter-key submission.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a3c02c5c8327a8ccb4d2d5d612f4)