### PR TITLE
Add interactive Member Portal with client-side login and Conscribo widgets; minor header cleanup

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -20,9 +20,7 @@ import '../styles/Components/header.css';
                 <li><a href="/strengthsports" class="nav-link">Strength Sports</a></li>
                 <li><a href="/committee" class="nav-link">Committees</a></li>
                 <li><a href="/contact" class="nav-link">Contact</a></li>
-                <li>
-                    <a href="/shop" class="nav-link">Shop</a>
-                </li>
+                <li><a href="/shop" class="nav-link">Shop</a></li>
                 <!-- New Member Portal Link -->
                 <li>
                     <a href="/member-portal" class="nav-link portal-link">

--- a/src/pages/member-portal.astro
+++ b/src/pages/member-portal.astro
@@ -2,455 +2,157 @@
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+
+const proxyUrl = 'https://tskv-conscribo-proxy.herman-skledar.workers.dev/';
+const widgets = {
+  details: 'af04808317',
+  events: '',
+  files: 'a071d903b8',
+};
 ---
 
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <BaseHead title="Member Portal | T.S.K.V. Spartacus" description="Access your T.S.K.V. Spartacus membership details, update your information, view association documents, and manage your account." />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
-    <style>
-        /* Portal page specific styles */
-        .portal-hero {
-            background: linear-gradient(rgba(55, 0, 27, 0.85), rgba(186, 19, 26, 0.75)), url('/images/hero-membership.jpg');
-            background-size: cover;
-            background-position: center;
-            padding: 120px 0 60px;
-            text-align: center;
-            margin-bottom: 60px;
-        }
-
-        .portal-hero h1 {
-            color: white;
-            margin-bottom: 15px;
-            font-size: 48px;
-        }
-
-        .portal-hero h2 {
-            color: var(--spartacus-yellow);
-            margin-bottom: 25px;
-            font-size: 28px;
-        }
-
-        .portal-container {
-            max-width: 1100px;
-            margin: 0 auto 80px;
-            padding: 0 20px;
-        }
-
-        .portal-intro {
-            background: white;
-            border-radius: 8px;
-            padding: 30px;
-            margin-bottom: 40px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-            text-align: center;
-            border-top: 5px solid var(--spartacus-red);
-        }
-
-        .portal-intro h2 {
-            color: var(--spartacus-burgundy);
-            margin-bottom: 20px;
-            font-size: 28px;
-            position: relative;
-            padding-bottom: 10px;
-            display: inline-block;
-        }
-
-        .portal-intro h2::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            height: 3px;
-            background: var(--spartacus-red);
-        }
-
-        .portal-intro p {
-            max-width: 800px;
-            margin: 0 auto 20px;
-            line-height: 1.7;
-            font-size: 16px;
-        }
-
-        .portal-features {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-            gap: 20px;
-            margin: 30px 0;
-        }
-
-        .portal-feature {
-            display: flex;
-            align-items: center;
-            background: #f8f8f8;
-            padding: 15px 20px;
-            border-radius: 8px;
-            min-width: 220px;
-        }
-
-        .feature-icon {
-            color: var(--spartacus-red);
-            font-size: 24px;
-            margin-right: 15px;
-        }
-
-        .feature-text {
-            font-weight: 500;
-        }
-
-        /* Tab Navigation */
-        .portal-tabs {
-            display: flex;
-            gap: 10px;
-            margin-bottom: 0;
-            flex-wrap: wrap;
-        }
-
-        .portal-tab {
-            flex: 1;
-            min-width: 200px;
-            padding: 20px 30px;
-            background: #f5f5f5;
-            border: none;
-            border-radius: 8px 8px 0 0;
-            cursor: pointer;
-            font-size: 16px;
-            font-weight: 600;
-            color: #666;
-            transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 12px;
-        }
-
-        .portal-tab:hover {
-            background: #e8e8e8;
-            color: var(--spartacus-burgundy);
-        }
-
-        .portal-tab.active {
-            background: white;
-            color: var(--spartacus-burgundy);
-            box-shadow: 0 -3px 0 var(--spartacus-red) inset;
-        }
-
-        .portal-tab i {
-            font-size: 20px;
-        }
-
-        .portal-tab-label {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            text-align: left;
-        }
-
-        .portal-tab-title {
-            font-size: 16px;
-        }
-
-        .portal-tab-subtitle {
-            font-size: 12px;
-            font-weight: 400;
-            opacity: 0.8;
-        }
-
-        /* Tab Content */
-        .portal-tab-content {
-            background: white;
-            border-radius: 0 0 8px 8px;
-            padding: 30px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-            min-height: 500px;
-        }
-
-        .portal-tab-pane {
-            display: none;
-        }
-
-        .portal-tab-pane.active {
-            display: block;
-        }
-
-        .tab-header {
-            text-align: center;
-            margin-bottom: 30px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid #eee;
-        }
-
-        .tab-header h3 {
-            color: var(--spartacus-burgundy);
-            font-size: 24px;
-            margin-bottom: 10px;
-        }
-
-        .tab-header p {
-            color: #666;
-            font-size: 15px;
-            max-width: 600px;
-            margin: 0 auto;
-        }
-
-        .conscribo-app-container {
-            width: 100%;
-            min-height: 450px;
-        }
-
-        /* Document categories info */
-        .document-categories {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 15px;
-            margin-bottom: 30px;
-        }
-
-        .doc-category {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 15px;
-            background: #f8f8f8;
-            border-radius: 8px;
-            border-left: 3px solid var(--spartacus-red);
-        }
-
-        .doc-category i {
-            font-size: 20px;
-            color: var(--spartacus-red);
-        }
-
-        .doc-category span {
-            font-weight: 500;
-            font-size: 14px;
-        }
-
-        .help-section {
-            margin-top: 60px;
-            text-align: center;
-        }
-
-        .help-section h3 {
-            color: var(--spartacus-burgundy);
-            margin-bottom: 20px;
-            font-size: 22px;
-        }
-
-        .help-section p {
-            margin-bottom: 20px;
-        }
-
-        .help-email {
-            display: inline-flex;
-            align-items: center;
-            color: var(--spartacus-red);
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s ease;
-        }
-
-        .help-email i {
-            margin-right: 8px;
-        }
-
-        .help-email:hover {
-            color: var(--spartacus-burgundy);
-        }
-
-        @media (max-width: 768px) {
-            .portal-hero {
-                padding: 100px 0 50px;
-            }
-
-            .portal-hero h1 {
-                font-size: 36px;
-            }
-
-            .portal-hero h2 {
-                font-size: 22px;
-            }
-
-            .portal-features {
-                flex-direction: column;
-                align-items: center;
-            }
-
-            .portal-feature {
-                width: 100%;
-                max-width: 350px;
-            }
-
-            .portal-tabs {
-                flex-direction: column;
-            }
-
-            .portal-tab {
-                border-radius: 8px;
-                margin-bottom: 5px;
-            }
-
-            .portal-tab.active {
-                border-radius: 8px;
-                box-shadow: 0 0 0 2px var(--spartacus-red);
-            }
-
-            .portal-tab-content {
-                border-radius: 8px;
-            }
-
-            .document-categories {
-                grid-template-columns: 1fr 1fr;
-            }
-        }
-
-        @media (max-width: 480px) {
-            .document-categories {
-                grid-template-columns: 1fr;
-            }
-        }
-    </style>
+  <BaseHead title="Member Portal | T.S.K.V. Spartacus" description="Secure Spartacus member portal for profile edits, events, and shared files." />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+  <style>
+    .portal-shell{max-width:1150px;margin:120px auto 80px;padding:0 20px}.portal-card{background:#fff;border-radius:12px;box-shadow:0 6px 20px rgba(0,0,0,.08);padding:28px}.portal-hero{margin-bottom:24px;border-left:5px solid var(--spartacus-red)}.portal-hero h1{margin:0 0 8px;color:var(--spartacus-burgundy)}.portal-hero p{margin:0;color:#555;line-height:1.6}
+    .auth-grid{display:grid;grid-template-columns:1fr auto auto;gap:12px;margin-top:18px}.auth-input{padding:12px 14px;border:1px solid #ddd;border-radius:8px;font-size:15px}.auth-btn{padding:12px 20px;border:none;border-radius:8px;background:var(--spartacus-red);color:#fff;font-weight:700;cursor:pointer}.auth-btn.secondary{background:#374151}.auth-btn:disabled{opacity:.5;cursor:not-allowed}
+    .auth-status{margin-top:12px;font-size:14px}.auth-status.error{color:#b91c1c}.auth-status.success{color:#0f766e}
+    .portal-tabs{display:flex;gap:8px;flex-wrap:wrap;margin:28px 0 0}.portal-tab{border:none;border-radius:10px 10px 0 0;padding:14px 20px;background:#f3f4f6;color:#666;font-weight:700;cursor:pointer}.portal-tab.active{background:#fff;color:var(--spartacus-burgundy);box-shadow:inset 0 -3px 0 var(--spartacus-red)}
+    .portal-pane-wrap{background:#fff;border-radius:0 12px 12px 12px;box-shadow:0 6px 20px rgba(0,0,0,.08);padding:24px;min-height:420px}.portal-pane{display:none}.portal-pane.active{display:block}.pane-head h2{margin:0;color:var(--spartacus-burgundy)}.pane-head p{margin:8px 0 20px;color:#666}
+    .widget{min-height:260px;border:1px dashed #ddd;border-radius:10px;padding:12px;background:#fafafa}.hint{margin-top:14px;padding:12px;border-radius:8px;background:#fff8e1;font-size:14px}
+    .hidden-until-login{opacity:.45;pointer-events:none;transition:.2s}.hidden-until-login.unlocked{opacity:1;pointer-events:auto}
+    @media (max-width:768px){.portal-shell{margin-top:100px}.auth-grid{grid-template-columns:1fr 1fr}.auth-input{grid-column:1/-1}}
+  </style>
 </head>
 <body>
-    <!-- Header -->
-    <Header />
-
-    <!-- Hero Section -->
-    <section class="portal-hero">
-        <div class="container">
-            <h1>MEMBER PORTAL</h1>
-            <h2>MANAGE YOUR SPARTACUS MEMBERSHIP</h2>
-        </div>
+  <Header />
+  <main class="portal-shell">
+    <section class="portal-card portal-hero">
+      <h1>Spartacus Members Portal</h1>
+      <p>Edit your details, subscribe to events, and download files such as minutes and photos. Login only unlocks the page UI; Conscribo still handles authorization per widget.</p>
+      <form id="memberLoginForm" class="auth-grid">
+        <input id="memberIdentifier" class="auth-input" type="text" placeholder="Member code or email" autocomplete="username" required />
+        <button id="memberLoginButton" class="auth-btn" type="submit">Log in</button>
+        <button id="memberLogoutButton" class="auth-btn secondary" type="button" style="display:none;">Log out</button>
+      </form>
+      <div id="authStatus" class="auth-status" aria-live="polite"></div>
     </section>
 
-    <!-- Main Content -->
-    <main>
-        <div class="portal-container">
-            <!-- Introduction -->
-            <div class="portal-intro">
-                <h2>WELCOME TO YOUR MEMBERSHIP PORTAL</h2>
-                <p>This secure portal allows you to manage your T.S.K.V. Spartacus membership details and access important association documents. Update your personal information, view meeting minutes, financial reports, and photo albums.</p>
+    <section class="hidden-until-login" id="portalContent">
+      <div class="portal-tabs" role="tablist" aria-label="Member Portal Sections">
+        <button class="portal-tab active" role="tab" aria-selected="true" aria-controls="details-tab" id="tab-details" data-tab="details"><i class="fas fa-user-edit"></i> My Details</button>
+        <button class="portal-tab" role="tab" aria-selected="false" aria-controls="events-tab" id="tab-events" data-tab="events"><i class="fas fa-calendar-check"></i> Events</button>
+        <button class="portal-tab" role="tab" aria-selected="false" aria-controls="files-tab" id="tab-files" data-tab="files"><i class="fas fa-folder-open"></i> Files</button>
+      </div>
+      <div class="portal-pane-wrap">
+        <article class="portal-pane active" role="tabpanel" aria-labelledby="tab-details" id="details-tab"><div class="pane-head"><h2>Edit profile details</h2><p>Update address, phone, IBAN/payment, and emergency/contact details.</p></div><div class="widget" data-id={widgets.details}></div></article>
+        <article class="portal-pane" role="tabpanel" aria-labelledby="tab-events" id="events-tab"><div class="pane-head"><h2>View & subscribe to events</h2><p>See upcoming activities, open event pages, and register directly.</p></div>{widgets.events ? (<div class="widget" data-id={widgets.events}></div>) : (<div class="hint">Configure <code>widgets.events</code> with your Conscribo events block ID to enable event subscriptions.</div>)}</article>
+        <article class="portal-pane" role="tabpanel" aria-labelledby="tab-files" id="files-tab"><div class="pane-head"><h2>Download minutes, reports & photos</h2><p>Browse shared folders and committee media archives.</p></div><div class="widget" data-id={widgets.files}></div></article>
+      </div>
+    </section>
+  </main>
+  <Footer />
 
-                <div class="portal-features">
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-user-edit"></i></span>
-                        <span class="feature-text">Update Personal Info</span>
-                    </div>
+  <script async src="https://leden.conscribo.nl/TSKVSpartacus/portal/loader" type="module"></script>
+  <script define:vars={{ proxyUrl }}>
+    const storageKey = 'spartacus_portal_session';
+    const sessionTTL = 12 * 60 * 60 * 1000;
+    const portalContent = document.getElementById('portalContent');
+    const authStatus = document.getElementById('authStatus');
+    const form = document.getElementById('memberLoginForm');
+    const loginButton = document.getElementById('memberLoginButton');
+    const logoutButton = document.getElementById('memberLogoutButton');
+    const memberIdentifier = document.getElementById('memberIdentifier');
 
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-university"></i></span>
-                        <span class="feature-text">Manage Payment Details</span>
-                    </div>
+    const setUnlocked = (displayName) => {
+      portalContent.classList.add('unlocked');
+      logoutButton.style.display = 'inline-block';
+      authStatus.textContent = `Welcome ${displayName}. Portal unlocked.`;
+      authStatus.className = 'auth-status success';
+    };
 
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-folder-open"></i></span>
-                        <span class="feature-text">View Documents</span>
-                    </div>
+    const setLocked = (message = 'You are logged out.') => {
+      portalContent.classList.remove('unlocked');
+      logoutButton.style.display = 'none';
+      authStatus.textContent = message;
+      authStatus.className = 'auth-status';
+    };
 
-                    <div class="portal-feature">
-                        <span class="feature-icon"><i class="fas fa-images"></i></span>
-                        <span class="feature-text">Browse Photos</span>
-                    </div>
-                </div>
-            </div>
+    async function loginMember() {
+      const identifier = memberIdentifier.value.trim();
+      if (!identifier) return;
 
-            <!-- Conscribo Portal Loader -->
-            <script async src="https://leden.conscribo.nl/TSKVSpartacus/portal/loader" type="module"></script>
+      loginButton.disabled = true;
+      authStatus.textContent = 'Checking membership…';
+      authStatus.className = 'auth-status';
 
-            <!-- Tab Navigation -->
-            <div class="portal-tabs">
-                <button class="portal-tab active" data-tab="membership">
-                    <i class="fas fa-id-card"></i>
-                    <span class="portal-tab-label">
-                        <span class="portal-tab-title">Membership Details</span>
-                        <span class="portal-tab-subtitle">Update your information</span>
-                    </span>
-                </button>
-                <button class="portal-tab" data-tab="documents">
-                    <i class="fas fa-archive"></i>
-                    <span class="portal-tab-label">
-                        <span class="portal-tab-title">Association Documents</span>
-                        <span class="portal-tab-subtitle">Minutes, finances & photos</span>
-                    </span>
-                </button>
-            </div>
-
-            <!-- Tab Content -->
-            <div class="portal-tab-content">
-                <!-- Membership Details Tab -->
-                <div class="portal-tab-pane active" id="membership-tab">
-                    <div class="tab-header">
-                        <h3>YOUR MEMBERSHIP INFORMATION</h3>
-                        <p>View and update your personal details, contact information, and payment preferences.</p>
-                    </div>
-                    <div class="conscribo-app-container" data-id="af04808317"></div>
-                </div>
-
-                <!-- Documents Tab -->
-                <div class="portal-tab-pane" id="documents-tab">
-                    <div class="tab-header">
-                        <h3>ASSOCIATION DOCUMENTS</h3>
-                        <p>Access meeting minutes, financial reports, photos, and other important association files.</p>
-                    </div>
-                    <div class="document-categories">
-                        <div class="doc-category">
-                            <i class="fas fa-file-alt"></i>
-                            <span>Meeting Minutes</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-chart-pie"></i>
-                            <span>Financial Reports</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-camera"></i>
-                            <span>Photo Albums</span>
-                        </div>
-                        <div class="doc-category">
-                            <i class="fas fa-file-contract"></i>
-                            <span>Policies</span>
-                        </div>
-                    </div>
-                    <div class="conscribo-app-container" data-id="a071d903b8"></div>
-                </div>
-            </div>
-
-            <!-- Help Section -->
-            <div class="help-section">
-                <h3>NEED ASSISTANCE?</h3>
-                <p>If you encounter any issues or have questions about your membership, please contact our secretary:</p>
-                <a href="mailto:secretary@tskvspartacus.nl" class="help-email">
-                    <i class="fas fa-envelope"></i> secretary@tskvspartacus.nl
-                </a>
-            </div>
-        </div>
-    </main>
-
-    <!-- Footer -->
-    <Footer />
-
-    <script>
-        // Tab switching functionality
-        document.addEventListener('DOMContentLoaded', function() {
-            const tabs = document.querySelectorAll('.portal-tab');
-            const panes = document.querySelectorAll('.portal-tab-pane');
-
-            tabs.forEach(tab => {
-                tab.addEventListener('click', function() {
-                    const targetTab = this.dataset.tab;
-
-                    // Remove active class from all tabs and panes
-                    tabs.forEach(t => t.classList.remove('active'));
-                    panes.forEach(p => p.classList.remove('active'));
-
-                    // Add active class to clicked tab and corresponding pane
-                    this.classList.add('active');
-                    document.getElementById(targetTab + '-tab').classList.add('active');
-                });
-            });
+      try {
+        const response = await fetch(proxyUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'login', identifier })
         });
-    </script>
+
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok || !payload.success || !payload.member) {
+          throw new Error(payload?.error?.message || 'Unable to verify membership.');
+        }
+
+        const displayName = payload.member.fullName || payload.member.code || 'member';
+        localStorage.setItem(storageKey, JSON.stringify({ displayName, issuedAt: Date.now() }));
+        setUnlocked(displayName);
+      } catch (error) {
+        authStatus.textContent = error.message;
+        authStatus.className = 'auth-status error';
+      } finally {
+        loginButton.disabled = false;
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const tabs = [...document.querySelectorAll('.portal-tab')];
+      const panes = [...document.querySelectorAll('.portal-pane')];
+
+      tabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+          tabs.forEach((t) => {
+            const active = t === tab;
+            t.classList.toggle('active', active);
+            t.setAttribute('aria-selected', String(active));
+          });
+          panes.forEach((p) => p.classList.remove('active'));
+          document.getElementById(`${tab.dataset.tab}-tab`)?.classList.add('active');
+        });
+      });
+
+      const rawSession = localStorage.getItem(storageKey);
+      if (rawSession) {
+        try {
+          const session = JSON.parse(rawSession);
+          if (Date.now() - Number(session.issuedAt) < sessionTTL && session.displayName) {
+            setUnlocked(session.displayName);
+          } else {
+            localStorage.removeItem(storageKey);
+          }
+        } catch {
+          localStorage.removeItem(storageKey);
+        }
+      }
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        loginMember();
+      });
+
+      logoutButton.addEventListener('click', () => {
+        localStorage.removeItem(storageKey);
+        memberIdentifier.value = '';
+        setLocked();
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide an interactive, responsive member portal that lets visitors unlock UI for Conscribo widgets after verifying membership without exposing widget authorization in the public UI. 
- Simplify and modernize the portal's layout, styling and tabbed navigation for details, events and files. 
- Add a lightweight client-side session mechanism so users remain unlocked for a limited time. 
- Tidy a small header markup inconsistency to keep markup compact.

### Description
- Rewrote `src/pages/member-portal.astro` to replace the large inline styles and static content with a compact componentized layout, new CSS, and a responsive tab UI for `details`, `events`, and `files` widgets. 
- Added `proxyUrl` and `widgets` configuration at the top of the page and placed the Conscribo loader (`https://leden.conscribo.nl/TSKVSpartacus/portal/loader`) to initialize widget areas via `data-id` attributes. 
- Implemented a client-side login form and `loginMember` flow that POSTs an identifier to the configured `proxyUrl`, validates the response, stores a short-lived session in `localStorage` under `spartacus_portal_session`, and toggles page UI by adding/removing the `hidden-until-login.unlocked` state. 
- Added accessible tab and pane roles/attributes, keyboard-click behavior, and error/success status messaging; events widget is guarded behind a configuration check and shows a hint when not set. 
- Kept `Header` and `Footer` usage; simplified a `Shop` list item in `src/components/Header.astro` to remove extra markup lines.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a3c02c5c8327a8ccb4d2d5d612f4)